### PR TITLE
Replace Inventory with an in-combat healing ability.

### DIFF
--- a/src/main/java/dnd/combat/Combat.java
+++ b/src/main/java/dnd/combat/Combat.java
@@ -60,10 +60,10 @@ public class Combat {
         this.active = true;
         this.playerVictory = false;
 
-        //keep track of player, player's weapon, and player's heal cooldown (every 4 turns)
+        //keep track of player, player's weapon, and player's heal cooldown
         this.player = c;
         this.playerWeapon = c.getWeapon();
-        this.healCD = 4;
+        this.healCD = 0;
 
         //create monster generator and generate a monster
         this.myMonsterGenerator = new MonsterGenerator(this.player);


### PR DESCRIPTION
Removed option to open inventory during combat (may be re-implemented later, if time allows). Replaced inventory with an in-combat healing ability that allows the player to heal a random amount of HP (influenced by Character.healingDie and Character.level) every 4 turns.